### PR TITLE
Quitando doble modal a la hora de editar un pictograma

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -20,19 +20,16 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'en';
 
-  static String m0(namePictogram) =>
-      "¿Está seguro de actualizar el pictograma ${namePictogram}?";
-
-  static String m1(nameChild) =>
+  static String m0(nameChild) =>
       "¿Está seguro de avanzar de fase a ${nameChild}?";
 
-  static String m2(nameImage, nameChild) =>
+  static String m1(nameImage, nameChild) =>
       "¿Está seguro que desea eliminar el pictograma \'${nameImage}\' de \'${nameChild}\'?";
 
-  static String m3(namePictogram) =>
+  static String m2(namePictogram) =>
       "Se actualizó correctamente el pictograma personalizado: ${namePictogram}";
 
-  static String m4(numFase, nameChild) =>
+  static String m3(numFase, nameChild) =>
       "Se avanzó a la fase ${numFase} a ${nameChild}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -105,12 +102,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "Esta_Seguro_de_actualizar_los_datos":
             MessageLookupByLibrary.simpleMessage(
                 "¿Está seguro de actualizar los datos?"),
-        "Esta_seguro_de_actualizar_el_pictograma": m0,
-        "Esta_seguro_de_avanzar_de_fase_a": m1,
+        "Esta_seguro_de_avanzar_de_fase_a": m0,
         "Esta_seguro_de_salir_de_la_edicion":
             MessageLookupByLibrary.simpleMessage(
                 "¿Está seguro de salir de la edición?"),
-        "Esta_seguro_que_desea_eliminar_el_pictograma": m2,
+        "Esta_seguro_que_desea_eliminar_el_pictograma": m1,
         "Fases": MessageLookupByLibrary.simpleMessage("Fases"),
         "Fecha_de_nacimiento":
             MessageLookupByLibrary.simpleMessage("Fecha de nacimiento"),
@@ -171,8 +167,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Quitar actividad"),
         "Restablecer_contrasena":
             MessageLookupByLibrary.simpleMessage("Restablecer contraseña"),
-        "Se_actualizo_correctamente_el_pictograma_personalizado": m3,
-        "Se_avanzo_a_la_fase": m4,
+        "Se_actualizo_correctamente_el_pictograma_personalizado": m2,
+        "Se_avanzo_a_la_fase": m3,
         "Segundo_apellido":
             MessageLookupByLibrary.simpleMessage("Segundo Apellido"),
         "Segundo_nombre":

--- a/lib/generated/intl/messages_es_NI.dart
+++ b/lib/generated/intl/messages_es_NI.dart
@@ -20,19 +20,16 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'es_NI';
 
-  static String m0(namePictogram) =>
-      "¿Está seguro de actualizar el pictograma ${namePictogram}?";
-
-  static String m1(nameChild) =>
+  static String m0(nameChild) =>
       "¿Está seguro de avanzar de fase a ${nameChild}?";
 
-  static String m2(nameImage, nameChild) =>
+  static String m1(nameImage, nameChild) =>
       "¿Está seguro que desea eliminar el pictograma \'${nameImage}\' de \'${nameChild}\'?";
 
-  static String m3(namePictogram) =>
+  static String m2(namePictogram) =>
       "Se actualizó correctamente el pictograma personalizado: ${namePictogram}";
 
-  static String m4(numFase, nameChild) =>
+  static String m3(numFase, nameChild) =>
       "Se avanzó a la fase ${numFase} a ${nameChild}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -105,12 +102,11 @@ class MessageLookup extends MessageLookupByLibrary {
         "Esta_Seguro_de_actualizar_los_datos":
             MessageLookupByLibrary.simpleMessage(
                 "¿Está seguro de actualizar los datos?"),
-        "Esta_seguro_de_actualizar_el_pictograma": m0,
-        "Esta_seguro_de_avanzar_de_fase_a": m1,
+        "Esta_seguro_de_avanzar_de_fase_a": m0,
         "Esta_seguro_de_salir_de_la_edicion":
             MessageLookupByLibrary.simpleMessage(
                 "¿Está seguro de salir de la edición?"),
-        "Esta_seguro_que_desea_eliminar_el_pictograma": m2,
+        "Esta_seguro_que_desea_eliminar_el_pictograma": m1,
         "Fases": MessageLookupByLibrary.simpleMessage("Fases"),
         "Fecha_de_nacimiento":
             MessageLookupByLibrary.simpleMessage("Fecha de nacimiento"),
@@ -171,8 +167,8 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Quitar actividad"),
         "Restablecer_contrasena":
             MessageLookupByLibrary.simpleMessage("Restablecer contraseña"),
-        "Se_actualizo_correctamente_el_pictograma_personalizado": m3,
-        "Se_avanzo_a_la_fase": m4,
+        "Se_actualizo_correctamente_el_pictograma_personalizado": m2,
+        "Se_avanzo_a_la_fase": m3,
         "Segundo_apellido":
             MessageLookupByLibrary.simpleMessage("Segundo Apellido"),
         "Segundo_nombre":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -921,16 +921,6 @@ class S {
     );
   }
 
-  /// `¿Está seguro de actualizar el pictograma {namePictogram}?`
-  String Esta_seguro_de_actualizar_el_pictograma(Object namePictogram) {
-    return Intl.message(
-      '¿Está seguro de actualizar el pictograma $namePictogram?',
-      name: 'Esta_seguro_de_actualizar_el_pictograma',
-      desc: '',
-      args: [namePictogram],
-    );
-  }
-
   /// `Se actualizó correctamente el pictograma personalizado: {namePictogram}`
   String Se_actualizo_correctamente_el_pictograma_personalizado(
       Object namePictogram) {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -86,7 +86,6 @@
   "Si_salir": "Si, Salir",
   "Esta_seguro_de_salir_de_la_edicion": "¿Está seguro de salir de la edición?",
   "Informacion_personal_actualizada": "Información personal actualizada",
-  "Esta_seguro_de_actualizar_el_pictograma": "¿Está seguro de actualizar el pictograma {namePictogram}?",
   "Se_actualizo_correctamente_el_pictograma_personalizado": "Se actualizó correctamente el pictograma personalizado: {namePictogram}",
   "Total_de_resultados": "Total de resultados:",
   "Lista_de_pictogramas_generales": "Lista de pictogramas generales",

--- a/lib/l10n/intl_es_NI.arb
+++ b/lib/l10n/intl_es_NI.arb
@@ -86,7 +86,6 @@
   "Si_salir": "Si, Salir",
   "Esta_seguro_de_salir_de_la_edicion": "¿Está seguro de salir de la edición?",
   "Informacion_personal_actualizada": "Información personal actualizada",
-  "Esta_seguro_de_actualizar_el_pictograma": "¿Está seguro de actualizar el pictograma {namePictogram}?",
   "Se_actualizo_correctamente_el_pictograma_personalizado": "Se actualizó correctamente el pictograma personalizado: {namePictogram}",
   "Total_de_resultados": "Total de resultados:",
   "Lista_de_pictogramas_generales": "Lista de pictogramas generales",

--- a/lib/presentation/utils/toast_alert.dart
+++ b/lib/presentation/utils/toast_alert.dart
@@ -49,7 +49,6 @@ void toastAlert(
       showProgressBar: true,
       closeButtonShowType: CloseButtonShowType.none,
       closeOnClick: false,
-      applyBlurEffect: true,
       pauseOnHover: true,
       progressBarTheme: ProgressIndicatorThemeData(
         color: colorProgressBar[typeAlert],

--- a/lib/presentation/widgets/grid_images.dart
+++ b/lib/presentation/widgets/grid_images.dart
@@ -283,32 +283,15 @@ Future<void> _dialogImage(
               ),
               buttonColor: $colorBlueGeneral,
               onClic: () {
-                modalDialogConfirmation(
-                  context: context,
-                  question: RichText(
-                    textAlign: TextAlign.center,
-                    text: TextSpan(
-                      text: S.current
-                          .Esta_seguro_de_actualizar_el_pictograma('Manzana'),
-                      style:
-                          const TextStyle(fontSize: 16, color: $colorTextBlack),
-                    ),
-                  ),
-                  titleButtonConfirm: S.current.Si_actualizar,
-                  buttonColorConfirm: $colorSuccess,
-                  onClic: () {
-                    toastAlert(
-                        iconAlert: const Icon(Icons.update),
-                        context: context,
-                        title: S.current.Actualizado_con_exito,
-                        description: S.current
-                            .Se_actualizo_correctamente_el_pictograma_personalizado(
-                                'Manzana'), //TODO: Cambiar cuando este  listo el endpoint
-                        typeAlert: ToastificationType.info);
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pop();
-                  },
-                );
+                Navigator.of(context).pop();
+                toastAlert(
+                    iconAlert: const Icon(Icons.update),
+                    context: context,
+                    title: S.current.Actualizado_con_exito,
+                    description: S.current
+                        .Se_actualizo_correctamente_el_pictograma_personalizado(
+                            'Manzana'), //TODO: Cambiar cuando este  listo el endpoint
+                    typeAlert: ToastificationType.info);
               },
             ),
             ButtonTextIcon(
@@ -318,23 +301,7 @@ Future<void> _dialogImage(
               ),
               buttonColor: $colorError,
               onClic: () {
-                modalDialogConfirmation(
-                  context: context,
-                  buttonColorConfirm: $colorSuccess,
-                  question: RichText(
-                    textAlign: TextAlign.center,
-                    text: TextSpan(
-                      text: S.current.Esta_seguro_de_salir_de_la_edicion,
-                      style:
-                          const TextStyle(fontSize: 16, color: $colorTextBlack),
-                    ),
-                  ),
-                  titleButtonConfirm: S.current.Si_salir,
-                  onClic: () {
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pop();
-                  },
-                );
+                Navigator.of(context).pop();
               },
             )
           ],


### PR DESCRIPTION
## Description
Quitando segundo modal a la hora de editar un pictograma y querer salir de la edición y a la hora de confirmar la edición

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] All dependent changes have been merged and published in subsequent modules.
- [x] I have reviewed my code and corrected any spelling mistakes.
