### PR TITLE
feat: Creacion de datasources, repositories, page y provider

### DIFF
--- a/lib/domain/datasources/achievement.datasource.dart
+++ b/lib/domain/datasources/achievement.datasource.dart
@@ -1,0 +1,14 @@
+import 'package:hope_app/domain/domain.dart'
+    show PictogramAchievements, ResponseDataList, ResponseDataObject;
+
+abstract class AchievementDatasource {
+  Future<ResponseDataList<PictogramAchievements>> getAchievementByPatient({
+    required int indexPage,
+    required int idPatient,
+  });
+
+  Future<ResponseDataObject<PictogramAchievements>> assignAchievement({
+    required int patientId,
+    required int achievementId,
+  });
+}

--- a/lib/domain/domain.dart
+++ b/lib/domain/domain.dart
@@ -45,3 +45,6 @@ export 'repositories/pictograms.repository.dart';
 
 export 'datasources/phases.datasource.dart';
 export 'repositories/phase.repository.dart';
+
+export 'datasources/achievement.datasource.dart';
+export 'repositories/achievement.repository.dart';

--- a/lib/domain/repositories/achievement.repository.dart
+++ b/lib/domain/repositories/achievement.repository.dart
@@ -1,0 +1,14 @@
+import 'package:hope_app/domain/domain.dart'
+    show PictogramAchievements, ResponseDataList, ResponseDataObject;
+
+abstract class AchievementRepository {
+  Future<ResponseDataList<PictogramAchievements>> getAchievementByPatient({
+    required int indexPage,
+    required int idPatient,
+  });
+
+  Future<ResponseDataObject<PictogramAchievements>> assignAchievement({
+    required int patientId,
+    required int achievementId,
+  });
+}

--- a/lib/infrastructure/datasources/achievement.datasource.impl.dart
+++ b/lib/infrastructure/datasources/achievement.datasource.impl.dart
@@ -1,0 +1,56 @@
+import 'package:hope_app/domain/domain.dart'
+    show
+        AchievementDatasource,
+        PictogramAchievements,
+        ResponseDataList,
+        ResponseDataObject;
+import 'package:hope_app/infrastructure/infrastructure.dart'
+    show ErrorHandler, PictogramsMapper, ResponseMapper;
+import 'package:hope_app/presentation/services/services.dart';
+import 'package:hope_app/presentation/utils/utils.dart';
+
+class AchievementDatasourceImpl extends AchievementDatasource {
+  final dioServices = DioService();
+
+  @override
+  Future<ResponseDataObject<PictogramAchievements>> assignAchievement({
+    required int patientId,
+    required int achievementId,
+  }) async {
+    try {
+      final response = await dioServices.dio.post(
+        '/achievements/assign-achievement',
+        data: {$patientIdAchievement: patientId, $achievementId: achievementId},
+      );
+
+      final responseAchievement =
+          ResponseMapper.responseJsonToEntity<PictogramAchievements>(
+              json: response.data,
+              fromJson: PictogramsMapper.pictogramAchievementsfromJson);
+
+      return responseAchievement;
+    } catch (e) {
+      ErrorHandler.handleError(e);
+    }
+  }
+
+  @override
+  Future<ResponseDataList<PictogramAchievements>> getAchievementByPatient({
+    required int indexPage,
+    required int idPatient,
+  }) async {
+    try {
+      final response = await dioServices.dio
+          .get('/achievements?page=$indexPage&size=15&patientId=$idPatient');
+
+      final responsechievements =
+          ResponseMapper.responseJsonListToEntity<PictogramAchievements>(
+              json: response.data,
+              fromJson: PictogramsMapper.pictogramAchievementsfromJson);
+
+      return responsechievements;
+    } catch (e) {
+      ErrorHandler.handleError(e);
+    }
+  }
+}

--- a/lib/infrastructure/infrastructure.dart
+++ b/lib/infrastructure/infrastructure.dart
@@ -22,6 +22,9 @@ export 'repositories/pictograms.repository.impl.dart';
 export 'datasources/phases.datasource.impl.dart';
 export 'repositories/phases.repository.impl.dart';
 
+export 'datasources/achievement.datasource.impl.dart';
+export 'repositories/achievement.repository.impl.dart';
+
 export 'mappers/profile_person.mapper.dart';
 export 'mappers/response_data.mapper.dart';
 export 'mappers/token.mapper.dart';

--- a/lib/infrastructure/repositories/achievement.repository.impl.dart
+++ b/lib/infrastructure/repositories/achievement.repository.impl.dart
@@ -1,0 +1,38 @@
+import 'package:hope_app/domain/domain.dart'
+    show
+        AchievementDatasource,
+        AchievementRepository,
+        PictogramAchievements,
+        ResponseDataList,
+        ResponseDataObject;
+import 'package:hope_app/infrastructure/infrastructure.dart'
+    show AchievementDatasourceImpl;
+
+class AchievementRespositoryImpl extends AchievementRepository {
+  final AchievementDatasource dataSource;
+
+  AchievementRespositoryImpl({AchievementDatasource? dataSource})
+      : dataSource = dataSource ?? AchievementDatasourceImpl();
+
+  @override
+  Future<ResponseDataObject<PictogramAchievements>> assignAchievement({
+    required int patientId,
+    required int achievementId,
+  }) {
+    return dataSource.assignAchievement(
+      patientId: patientId,
+      achievementId: achievementId,
+    );
+  }
+
+  @override
+  Future<ResponseDataList<PictogramAchievements>> getAchievementByPatient({
+    required int indexPage,
+    required int idPatient,
+  }) {
+    return dataSource.getAchievementByPatient(
+      indexPage: indexPage,
+      idPatient: idPatient,
+    );
+  }
+}

--- a/lib/presentation/pages/achievement/achievements.page.dart
+++ b/lib/presentation/pages/achievement/achievements.page.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:hope_app/domain/domain.dart'
+    show CatalogObject, PictogramAchievements;
+import 'package:hope_app/generated/l10n.dart';
+import 'package:hope_app/presentation/providers/providers.dart';
+import 'package:hope_app/presentation/utils/utils.dart';
+import 'package:hope_app/presentation/widgets/widgets.dart';
+import 'package:toastification/toastification.dart';
+
+class AchievementPage extends ConsumerStatefulWidget {
+  final int idChild;
+  final Map<String, dynamic>? extra;
+
+  const AchievementPage({
+    super.key,
+    required this.idChild,
+    required this.extra,
+  });
+
+  @override
+  AchievementPageState createState() => AchievementPageState();
+}
+
+class AchievementPageState extends ConsumerState<AchievementPage> {
+  final scrollController = ScrollController();
+
+  @override
+  Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
+
+    Future.microtask(() async {
+      final notifierAchievement = ref.read(achievementProvider.notifier);
+      notifierAchievement.getAchievements(idPatient: widget.idChild);
+
+      scrollController.addListener(() async {
+        final statePictograms = ref.read(achievementProvider);
+
+        if ((scrollController.position.pixels + 50) >=
+                scrollController.position.maxScrollExtent &&
+            statePictograms.isLoading == false) {
+          if (statePictograms.paginateAchievement[$indexPage]! > 1 &&
+              statePictograms.paginateAchievement[$indexPage]! <=
+                  statePictograms.paginateAchievement[$pageCount]!) {
+            await notifierAchievement.getAchievements(
+              idPatient: widget.idChild,
+            );
+          }
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stateAchievement = ref.watch(achievementProvider);
+    final notifierAchievement = ref.read(achievementProvider.notifier);
+
+    ref.listen(achievementProvider, (previous, next) {
+      if (next.isComplete == true) {
+        toastAlert(
+          context: context,
+          title: S.current.Asignacion_exitosa,
+          description: S.current.Se_asigno_el_logro_correctamente_al_paciente,
+          typeAlert: ToastificationType.success,
+        );
+        notifierAchievement.updateResponse();
+      }
+      if (next.errorMessageApi != null) {
+        toastAlert(
+          context: context,
+          title: S.current.Error,
+          description: next.errorMessageApi!,
+          typeAlert: ToastificationType.error,
+        );
+        notifierAchievement.updateResponse();
+      }
+    });
+
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(S.current.Logros_disponibles_paciente),
+          actions: [
+            Container(
+              margin: const EdgeInsets.only(right: 15),
+              child: IconButton(
+                icon: const Icon(Icons.help),
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Container(
+                          decoration: const BoxDecoration(
+                            borderRadius: BorderRadius.only(
+                                topLeft: Radius.circular(20),
+                                topRight: Radius.circular(20)),
+                            color: $colorBlueGeneral,
+                          ),
+                          padding: const EdgeInsets.only(
+                              left: 22, top: 20, bottom: 20),
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            S.current.Ayuda,
+                            style: const TextStyle(
+                              color: $colorTextWhite,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        titlePadding: EdgeInsets.zero,
+                        content: SizedBox(
+                          width: 200,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                S.current
+                                    .Si_el_nombre_del_logro_no_se_muestra_completo_puede,
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold),
+                              ),
+                              const SizedBox(height: 10),
+                              Text(
+                                S.current
+                                    .Mantener_el_dedo_sobre_el_nombre_durante_1_segundo_para_verlo_completo,
+                              ),
+                              const SizedBox(height: 30),
+                              Text(
+                                S.current.Para_ver_la_imagen_con_mas_detalle,
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold),
+                              ),
+                              const SizedBox(height: 10),
+                              Text(
+                                S.current.Hacer_doble_clic_sobre_la_imagen,
+                              ),
+                              const SizedBox(height: 30),
+                              Text(
+                                S.current.Para_asignar_un_logro,
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold),
+                              ),
+                              const SizedBox(height: 10),
+                              Text(
+                                S.current
+                                    .Dar_clic_en_el_icono_de_ubicado_debajo_de_la_imagen_del_logro,
+                              ),
+                            ],
+                          ),
+                        ),
+                        insetPadding: EdgeInsets.zero,
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+        body: Stack(
+          children: [
+            if (stateAchievement.paginateAchievement[$indexPage] != 1)
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 15, vertical: 15),
+                child: stateAchievement.achievement.isNotEmpty
+                    ? GridView.builder(
+                        controller: scrollController,
+                        gridDelegate:
+                            const SliverGridDelegateWithMaxCrossAxisExtent(
+                          maxCrossAxisExtent: 150,
+                          childAspectRatio: 0.6,
+                        ),
+                        itemCount: stateAchievement.achievement.length,
+                        itemBuilder: (context, index) {
+                          return _ImageGrid(
+                            pictogram: stateAchievement.achievement[index],
+                            ref: ref,
+                            childData: CatalogObject(
+                              id: widget.idChild,
+                              name: widget.extra![$nameChild],
+                              description: '',
+                            ),
+                          );
+                        },
+                      )
+                    : SvgPicture.asset(
+                        fit: BoxFit.contain,
+                        'assets/svg/SinDatos.svg',
+                      ),
+              ),
+            if (stateAchievement.isLoading == true &&
+                stateAchievement.paginateAchievement[$indexPage]! != 1)
+              const Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            // 🔄 LOADING
+            if (stateAchievement.paginateAchievement[$indexPage]! == 1) ...[
+              const Opacity(
+                opacity: 0.5,
+                child:
+                    ModalBarrier(dismissible: false, color: $colorTransparent),
+              ),
+              Center(
+                child: stateAchievement.isErrorInitial == true
+                    ? SvgPicture.asset(
+                        fit: BoxFit.contain,
+                        'assets/svg/SinDatos.svg',
+                      )
+                    : Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const CircularProgressIndicator(),
+                          const SizedBox(height: 25),
+                          Text(
+                            S.current.Cargando,
+                            style: const TextStyle(
+                              color: $colorButtonDisable,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                              decoration: TextDecoration.none,
+                            ),
+                          ),
+                        ],
+                      ),
+              ),
+            ],
+            if (stateAchievement.isAssign == true) ...[
+              const Opacity(
+                opacity: 0.5,
+                child: ModalBarrier(dismissible: false, color: $colorTextBlack),
+              ),
+              Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const CircularProgressIndicator(),
+                    const SizedBox(height: 25),
+                    Text(
+                      S.current.Cargando,
+                      style: const TextStyle(
+                        color: $colorTextWhite,
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ));
+  }
+}
+
+class _ImageGrid extends StatelessWidget {
+  final PictogramAchievements pictogram;
+  final WidgetRef ref;
+  final CatalogObject childData;
+
+  const _ImageGrid({
+    required this.pictogram,
+    required this.childData,
+    required this.ref,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final profileState = ref.read(profileProvider);
+    final notifierAchievement = ref.read(achievementProvider.notifier);
+
+    return Container(
+      padding: const EdgeInsets.only(top: 7),
+      child: Column(children: [
+        Container(
+          width: 110,
+          height: 110,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: $colorTextBlack, width: 0.5),
+            color: $colorTextWhite,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: ImageLoad(urlImage: pictogram.imageUrl),
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.only(top: 10),
+          child: Tooltip(
+            message: pictogram.name, // Muestra el nombre completo
+            waitDuration:
+                const Duration(milliseconds: 100), // Espera antes de mostrarse
+            showDuration: const Duration(seconds: 2), // Tiempo visible
+            child: Text(
+              pictogram.name,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Visibility(
+              child: Consumer(
+                builder: (context, ref, child) {
+                  return IconButton(
+                    tooltip: S.current.Asignar_Logro,
+                    onPressed: () {
+                      if (profileState.permmisions!
+                          .contains($assignAchievement)) {
+                        modalDialogConfirmation(
+                          context: context,
+                          question: RichText(
+                            text: TextSpan(
+                              children: [
+                                TextSpan(
+                                  text:
+                                      '${S.current.Esta_seguro_de_asignar_el_logro_al_paciente(pictogram.name)}\n\n',
+                                  style: const TextStyle(
+                                      fontSize: 14, color: $colorTextBlack),
+                                ),
+                                TextSpan(
+                                  text: childData.name,
+                                  style: const TextStyle(
+                                    fontSize: 14,
+                                    color: $colorTextBlack,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                )
+                              ],
+                            ),
+                          ),
+                          titleButtonConfirm: S.current.Si_asignar,
+                          onClic: () async {
+                            if (context.mounted) {
+                              Navigator.of(context).pop();
+                              await notifierAchievement.assignAchievement(
+                                achievementId: pictogram.id,
+                                idPatient: childData.id,
+                              );
+                            }
+                          },
+                        );
+                      } else {
+                        toastAlert(
+                          iconAlert: const Icon(Icons.info),
+                          context: context,
+                          title: S.current.No_autorizado,
+                          description:
+                              S.current.No_cuenta_con_el_permiso_necesario,
+                          typeAlert: ToastificationType.info,
+                        );
+                      }
+                    },
+                    icon: const Icon(Icons.add, color: $colorSuccess),
+                  );
+                },
+              ),
+            )
+          ],
+        )
+      ]),
+    );
+  }
+}

--- a/lib/presentation/pages/activities/new_activity.page.dart
+++ b/lib/presentation/pages/activities/new_activity.page.dart
@@ -183,7 +183,6 @@ class NewActivityState extends ConsumerState<NewActivityPage> {
                                 context: context,
                                 titleButtonConfirm: S.current.Si_guardar,
                                 question: RichText(
-                                  textAlign: TextAlign.center,
                                   text: TextSpan(
                                     text: S.current
                                         .Esta_seguro_de_crear_la_actividad,

--- a/lib/presentation/pages/pages.dart
+++ b/lib/presentation/pages/pages.dart
@@ -16,3 +16,4 @@ export 'activities/remove_activity.page.dart';
 export 'board/board.page.dart';
 export 'children/children_therapist.page.dart';
 export 'splash/splash_screen.page.dart';
+export 'achievement/achievements.page.dart';

--- a/lib/presentation/providers/achievement.provider.dart
+++ b/lib/presentation/providers/achievement.provider.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hope_app/domain/domain.dart';
+import 'package:hope_app/generated/l10n.dart';
+import 'package:hope_app/infrastructure/infrastructure.dart';
+import 'package:hope_app/presentation/utils/utils.dart';
+
+final achievementProvider =
+    StateNotifierProvider.autoDispose<AchievementNotifier, AchievementState>(
+        (ref) {
+  return AchievementNotifier(
+    achievementRepository: AchievementRespositoryImpl(),
+  );
+});
+
+class AchievementNotifier extends StateNotifier<AchievementState> {
+  final AchievementRespositoryImpl achievementRepository;
+
+  AchievementNotifier({required this.achievementRepository})
+      : super(AchievementState());
+
+  Future<void> getAchievements({required int idPatient}) async {
+    state = state.copyWith(isLoading: true);
+    final indexPage = state.paginateAchievement[$indexPage]!;
+    try {
+      final achievement = await achievementRepository.getAchievementByPatient(
+        indexPage: indexPage,
+        idPatient: idPatient,
+      );
+
+      Map<String, int> paginate = {
+        $indexPage: indexPage + 1,
+        $pageCount: achievement.paginate!.pageCount
+      };
+
+      state = state.copyWith(
+        paginateAchievement: paginate,
+        achievement: [...state.achievement, ...achievement.data!],
+        isLoading: false,
+        isErrorInitial: false,
+      );
+    } on CustomError catch (e) {
+      if (indexPage == 1) state = state.copyWith(isErrorInitial: true);
+      state = state.copyWith(errorMessageApi: e.message, isLoading: false);
+    } catch (e) {
+      if (indexPage == 1) state = state.copyWith(isErrorInitial: true);
+      state = state.copyWith(
+        errorMessageApi: S.current.Error_inesperado,
+        isLoading: false,
+      );
+    }
+  }
+
+  Future<void> assignAchievement({
+    required int idPatient,
+    required int achievementId,
+  }) async {
+    state = state.copyWith(isAssign: true);
+    try {
+      final achievement = await achievementRepository.assignAchievement(
+        achievementId: achievementId,
+        patientId: idPatient,
+      );
+
+      List<PictogramAchievements> listPictogram = List.from(state.achievement);
+      listPictogram.removeWhere((item) => item.id == achievement.data!.id);
+
+      state = state.copyWith(
+        isAssign: false,
+        achievement: listPictogram,
+        isComplete: true,
+      );
+    } on CustomError catch (e) {
+      state = state.copyWith(errorMessageApi: e.message, isAssign: false);
+    } catch (e) {
+      state = state.copyWith(
+        errorMessageApi: S.current.Error_inesperado,
+        isAssign: false,
+      );
+    }
+  }
+
+  void updateResponse() =>
+      state = state.copyWith(errorMessageApi: '', isComplete: false);
+}
+
+class AchievementState {
+  final bool? isLoading;
+  final bool? isAssign;
+  final bool? isComplete;
+  final String? errorMessageApi;
+  final bool? isErrorInitial;
+  final Map<String, int> paginateAchievement;
+  final List<PictogramAchievements> achievement;
+
+  AchievementState({
+    this.paginateAchievement = const {$indexPage: 1, $pageCount: 0},
+    this.achievement = const [],
+    this.isLoading,
+    this.isAssign,
+    this.isComplete,
+    this.errorMessageApi,
+    this.isErrorInitial,
+  });
+
+  AchievementState copyWith({
+    List<PictogramAchievements>? achievement,
+    Map<String, int>? paginateAchievement,
+    bool? isLoading,
+    bool? isAssign,
+    bool? isComplete,
+    bool? isErrorInitial,
+    String? errorMessageApi,
+  }) =>
+      AchievementState(
+        achievement: achievement ?? this.achievement,
+        paginateAchievement: paginateAchievement ?? this.paginateAchievement,
+        errorMessageApi: errorMessageApi == ''
+            ? null
+            : errorMessageApi ?? this.errorMessageApi,
+        isLoading: isLoading ?? this.isLoading,
+        isAssign: isAssign ?? this.isAssign,
+        isComplete: isComplete ?? this.isComplete,
+        isErrorInitial: isErrorInitial ?? this.isErrorInitial,
+      );
+}

--- a/lib/presentation/providers/activity.provider.dart
+++ b/lib/presentation/providers/activity.provider.dart
@@ -172,7 +172,7 @@ class ActivityNotifier extends StateNotifier<ActivityState> {
       if (state.activity!.description.length <= 5 ||
           state.activity!.description.length >= 255) {
         errors[$description] = S.current
-            .La_descripcion_no_puede_ser_menor_a_seis_o_mayor_a_docientocincuentaycinco_caracteres;
+            .La_descripcion_no_puede_ser_menor_a_seis_o_mayor_a_doscientoscincuentaycinco_caracteres;
       }
     }
 

--- a/lib/presentation/providers/change_password.provider.dart
+++ b/lib/presentation/providers/change_password.provider.dart
@@ -115,7 +115,7 @@ class ChangePasswordNotifier extends StateNotifier<ChangePasswordState> {
           .La_contrasena_debe_tener_entre_caracteres_ademas_contener_letras_y_numeros;
     }
     if (state.passwords!.newPassword != state.passwords!.confirmNewPassword) {
-      errors[$confirmNewPassword] = S.current.Las_contrasena_no_coinciden;
+      errors[$confirmNewPassword] = S.current.Las_contrasenas_no_coinciden;
     }
 
     state = state.copyWith(validationErrors: errors);

--- a/lib/presentation/providers/child.provider.dart
+++ b/lib/presentation/providers/child.provider.dart
@@ -264,7 +264,7 @@ class ChildNotifier extends StateNotifier<ChildState> {
       if (state.child!.address.length <= 5 ||
           state.child!.address.length >= 255) {
         errors[$addressProfile] = S.current
-            .La_direccion_no_puede_ser_menor_a_seis_o_mayor_a_docientocincuentaycinco_caracteres;
+            .La_direccion_no_puede_ser_menor_a_seis_o_mayor_a_doscientoscincuentaycinco_caracteres;
       }
     }
 

--- a/lib/presentation/providers/observation.provider.dart
+++ b/lib/presentation/providers/observation.provider.dart
@@ -51,7 +51,7 @@ class ObservationStateNotifier extends StateNotifier<ObservationState> {
         state.description!.length < 6) {
       state = state.copyWith(
           validationError: S.current
-              .La_descripcion_debe_tener_entre_seis_y_docientocincuentaycinco_caracteres);
+              .La_descripcion_debe_tener_entre_seis_y_doscientoscincuentaycinco_caracteres);
 
       return false;
     } else {

--- a/lib/presentation/providers/profile.provider.dart
+++ b/lib/presentation/providers/profile.provider.dart
@@ -346,7 +346,7 @@ class ProfileNotifier extends StateNotifier<ProfileState> {
       if (state.profile!.address.length <= 5 ||
           state.profile!.address.length >= 255) {
         errors[$addressProfile] = S.current
-            .La_direccion_no_puede_ser_menor_a_seis_o_mayor_a_docientocincuentaycinco_caracteres;
+            .La_direccion_no_puede_ser_menor_a_seis_o_mayor_a_doscientoscincuentaycinco_caracteres;
       }
     }
 

--- a/lib/presentation/providers/providers.dart
+++ b/lib/presentation/providers/providers.dart
@@ -14,3 +14,4 @@ export 'custom_pictogram.provider.dart';
 export 'observation.provider.dart';
 export 'activity_children.provider.dart';
 export 'board.provider.dart';
+export 'achievement.provider.dart';


### PR DESCRIPTION
## Description
- Se crearon datasources y repositories para la peticion de los endpoints de listado de logros disponibles para el paciente y asignacion de logro al paciente
- Se creo page achievement para para mostrar los logros que estan disponibles para el paciente y su posterior asignacion, mostrar alertas y boton de ayuda
- Se creo provider de achievement para gestionar el listado de logros y su asignacion, para poder consumir los endpoints

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

![photo_4956568156130881238_y](https://github.com/user-attachments/assets/bcee1788-29be-4b52-a91a-c28406d669b3)
![photo_4956568156130881237_y](https://github.com/user-attachments/assets/bf7559e4-fa02-4f61-b887-e7ca94a422c6)
![photo_4956568156130881236_y](https://github.com/user-attachments/assets/3e135160-9d44-4269-b42e-55be0ea278f1)
![photo_4956568156130881235_y](https://github.com/user-attachments/assets/6786d569-7e15-4129-a112-3d3e620d40d7)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] All dependent changes have been merged and published in subsequent modules.
- [x] I have reviewed my code and corrected any spelling mistakes.
